### PR TITLE
Community files and repo discoverability (Level 2/3 roadmap)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: A QR decodes incorrectly or the library misbehaves
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! You can write in English or Spanish.
+  - type: input
+    id: version
+    attributes:
+      label: Library version
+      placeholder: "1.0.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      multiple: true
+      options:
+        - Android
+        - iOS
+    validations:
+      required: true
+  - type: textarea
+    id: qr
+    attributes:
+      label: QR rawText (redacted)
+      description: >
+        The raw QR string that misbehaves. PLEASE REDACT personal data
+        (phone numbers, emails, account numbers in the key fields) —
+        keep the TLV structure intact so we can reproduce.
+      render: text
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior
+      description: Which field/tag decodes wrong? Reference the EASPBV tag if you know it.
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Acquirer network (Redeban/Credibanco/...), QR type (static/dynamic), stack traces, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/fgardila/qr-decoder-emv-co-kmp/discussions
+    about: For usage questions, prefer Discussions over issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest a new capability or spec field support
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! You can write in English or Spanish.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: >
+        If it's about a spec field, reference the EASPBV tag/sub-tag and
+        spec version (the v1.4-2025 PDF is in the repo root).
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+
+<!-- What does this PR change and why? If it touches decoding behavior,
+reference the EASPBV tag/sub-tag (spec PDF is in the repo root). -->
+
+## Checklist
+
+- [ ] Tests added/updated (`./gradlew :emvdecoder:allTests` green)
+- [ ] `CHANGELOG.md` updated under *Unreleased* (for user-visible changes)
+- [ ] No validations that reject QRs — the decoder stays lenient by design

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ captures/
 gpg-maven-central-secrets.txt
 *.asc
 
+# Notas locales de planeación
+pending/
+
 # External native build folder generated in Android Studio
 .externalNativeBuild
 .cxx/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-06-11
+
+First public release on Maven Central: `dev.code93:emvdecoder:1.0.0`.
+
+### Added
+
+- Kotlin Multiplatform EMVCo QR decoder for the Colombian EASPBV v1.4-2025
+  standard (Android AAR + iOS frameworks for `iosArm64`/`iosSimulatorArm64`).
+- Full TLV parsing of conventions, merchant information (immediate-payment
+  keys / Llaves, acquirer network, merchant and aggregator codes), additional
+  merchant information (MCC, location, IVA/INC taxes, channel), transaction
+  detail (amount, currency, tips), additional data fields (tag 62),
+  alternate-language template (tag 64), transfer/collection fields (92–98)
+  and discount application (tag 99).
+- Transaction ID mapped from tag `90` (`TRXID`) per spec v1.4, with a legacy
+  fallback to tag `86` for QRs issued under older spec versions.
+- `CRCValidator` — opt-in CRC-16/CCITT-FALSE integrity check.
+- Test suite with real Redeban QR samples, synthetic full-coverage QRs,
+  malformed-input cases and the standard CRC test vector, running on Android
+  host and iOS simulator.
+- Demo apps: Jetpack Compose (CameraX + ML Kit) and SwiftUI.
+- CI (GitHub Actions) and automated Maven Central releases on `v*` tags.
+
+### Changed
+
+- Project migrated to the recommended KMP structure with Gradle 9.5.1,
+  AGP 9.2.1 (`com.android.kotlin.multiplatform.library`) and Kotlin 2.3.21.
+- Relicensed from GPL-3.0 to MIT (matching the source file headers).
+
+[Unreleased]: https://github.com/fgardila/qr-decoder-emv-co-kmp/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/fgardila/qr-decoder-emv-co-kmp/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+Thanks for your interest in improving this library! Issues and pull requests
+are welcome, in English or Spanish.
+
+## Development setup
+
+- **JDK 17+** (to run Gradle), Android SDK with API 36, and Xcode (only for
+  the iOS demo app / simulator tests).
+- Useful commands:
+
+```bash
+./gradlew :emvdecoder:allTests                 # run the full test suite (Android host + iOS simulator)
+./gradlew :emvdecoder:testAndroidHostTest      # Android/JVM tests only (fastest loop)
+./gradlew :emvdecoder:assemble                 # build the AAR
+./gradlew :androidApp:assembleDebug            # build the Android demo app
+```
+
+## Guidelines
+
+- **The decoder is lenient by design**: malformed input must never throw.
+  Standard compliance is the authorizing backend's responsibility, not this
+  client library's. Please don't add validations that reject QRs.
+- **Follow the spec**: field semantics come from the EASPBV standard — the
+  PDF (`EASPBV-Campos-QRCode-EMVCo-Industria-v1.4-2025.pdf`) is in the repo
+  root. Reference the tag/sub-tag in your PR description.
+- **Tests are required** for behavior changes. Build test payloads with the
+  TLV/CRC helpers in `emvdecoder/src/commonTest/.../EmvQrTestBuilder.kt`. If
+  you have a real-world QR that decodes incorrectly, include it (redact any
+  personal data such as phone numbers or emails in the key fields).
+- **Public API changes** need a matching entry in `CHANGELOG.md` under
+  *Unreleased*, and follow semantic versioning (breaking changes target the
+  next major release).
+- CI must be green (Android + iOS jobs) before review.
+
+## Releasing (maintainers)
+
+Bump the version in the `coordinates(...)` call in
+`emvdecoder/build.gradle.kts`, update `CHANGELOG.md`, merge to `main`, and
+push a `vX.Y.Z` tag — the release workflow publishes to Maven Central and
+creates the GitHub Release.

--- a/README.es.md
+++ b/README.es.md
@@ -101,6 +101,10 @@ iosApp/       App demo — SwiftUI (enlaza el framework vía embedAndSignAppleFr
 
 La suite incluye QRs reales de Redeban, QRs sintéticos de cobertura completa construidos con un helper TLV/CRC, casos de entrada malformada y el vector estándar CRC-16/CCITT-FALSE (`"123456789" → 0x29B1`).
 
+## Contribuir
+
+Issues y PRs son bienvenidos (en español o inglés) — mira [CONTRIBUTING.md](CONTRIBUTING.md). Los cambios se registran en el [CHANGELOG](CHANGELOG.md).
+
 ## Licencia
 
 [MIT](LICENSE). La lógica de validación CRC deriva de [emv_qrcode](https://github.com/mohamedayed/emv_qrcode) de Mohamed Ayed (MIT).

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ iosApp/       Demo app — SwiftUI (links the framework via embedAndSignAppleFra
 
 The suite includes real Redeban QR samples, full-coverage synthetic QRs built with a TLV/CRC helper, malformed-input cases, and the standard CRC-16/CCITT-FALSE test vector (`"123456789" → 0x29B1`).
 
+## Contributing
+
+Issues and PRs are welcome (English or Spanish) — see [CONTRIBUTING.md](CONTRIBUTING.md). Changes are tracked in the [CHANGELOG](CHANGELOG.md).
+
 ## License
 
 [MIT](LICENSE). The CRC validation logic is derived from [emv_qrcode](https://github.com/mohamedayed/emv_qrcode) by Mohamed Ayed (MIT).


### PR DESCRIPTION
## Summary

- `CHANGELOG.md` (Keep a Changelog) with the 1.0.0 entry
- `CONTRIBUTING.md` with dev setup and the lenient-by-design guideline
- Issue forms (bug report with QR redaction guidance, feature request, config with Discussions link) and PR template
- READMEs link to CONTRIBUTING/CHANGELOG
- `.gitignore`: local `pending/` planning notes folder

Repo-level (already applied via `gh repo edit`): description, homepage → Maven Central artifact, 10 topics, Discussions enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)