### PR TITLE
Fix crash on gallery QR detection (double continuation resume)

### DIFF
--- a/iosApp/iosApp/Data/VisionQrImageDecoder.swift
+++ b/iosApp/iosApp/Data/VisionQrImageDecoder.swift
@@ -4,26 +4,26 @@ import Vision
 /// Detecta y extrae el rawText de un QR dentro de una imagen usando Vision.
 struct VisionQrImageDecoder: QrImageDecoding {
 
+    /// `perform` es síncrono: se ejecuta fuera del main thread y se leen los
+    /// resultados al terminar. Sin continuations — un único camino de retorno
+    /// (usar el completion handler del request + catch del perform produce
+    /// doble resume cuando Vision falla, p. ej. en el simulador).
     func decodeQr(from image: UIImage) async -> String? {
         guard let cgImage = image.cgImage else { return nil }
 
-        return await withCheckedContinuation { continuation in
-            let request = VNDetectBarcodesRequest { request, _ in
-                let payload = (request.results as? [VNBarcodeObservation])?
-                    .first { $0.symbology == .qr }?
-                    .payloadStringValue
-                continuation.resume(returning: payload)
-            }
+        return await Task.detached(priority: .userInitiated) {
+            let request = VNDetectBarcodesRequest()
             request.symbologies = [.qr]
 
             let handler = VNImageRequestHandler(cgImage: cgImage)
-            DispatchQueue.global(qos: .userInitiated).async {
-                do {
-                    try handler.perform([request])
-                } catch {
-                    continuation.resume(returning: nil)
-                }
+            do {
+                try handler.perform([request])
+            } catch {
+                return nil
             }
-        }
+            return request.results?
+                .first { $0.symbology == .qr }?
+                .payloadStringValue
+        }.value
     }
 }


### PR DESCRIPTION
## Summary

Selecting a gallery image on iOS crashed with `SWIFT TASK CONTINUATION MISUSE: decodeQr(from:) tried to resume its continuation more than once`. When Vision fails (e.g. on the simulator), the `VNDetectBarcodesRequest` completion handler fires **and** `handler.perform()` throws — both paths resumed the same `CheckedContinuation`.

Fix: `perform()` is synchronous, so the continuation was never needed. Run detection in a `Task.detached` and read `request.results` after `perform` returns — single return path, crash impossible by construction.

## Test plan
- [x] `xcodebuild` simulator build green
- [x] Manual: gallery pick on simulator no longer crashes (returns "no QR found" path when Vision can't detect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)