### PR TITLE
Copy-to-clipboard icon on decoded QR fields (Android + iOS)

### DIFF
--- a/androidApp/src/main/kotlin/dev/code93/emvqr/core/designsystem/components/KeyValueRow.kt
+++ b/androidApp/src/main/kotlin/dev/code93/emvqr/core/designsystem/components/KeyValueRow.kt
@@ -1,36 +1,61 @@
 package dev.code93.emvqr.core.designsystem.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import dev.code93.emvqr.R
 
 @Composable
 fun KeyValueRow(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
-    monospace: Boolean = false
+    monospace: Boolean = false,
+    onCopy: (() -> Unit)? = null
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(vertical = 6.dp)
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyLarge,
-            fontFamily = if (monospace) FontFamily.Monospace else null
-        )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(vertical = 6.dp)
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyLarge,
+                fontFamily = if (monospace) FontFamily.Monospace else null
+            )
+        }
+        if (onCopy != null) {
+            IconButton(onClick = onCopy) {
+                Icon(
+                    imageVector = Icons.Filled.ContentCopy,
+                    contentDescription = stringResource(R.string.copy_value),
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.outline
+                )
+            }
+        }
     }
 }

--- a/androidApp/src/main/kotlin/dev/code93/emvqr/presentation/scanner/components/ResultSections.kt
+++ b/androidApp/src/main/kotlin/dev/code93/emvqr/presentation/scanner/components/ResultSections.kt
@@ -17,7 +17,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import dev.code93.emvqr.R
 import dev.code93.emvqr.core.designsystem.components.KeyValueRow
@@ -94,12 +96,14 @@ fun DecodedResult(
 
 @Composable
 fun SectionContent(section: EmvSection, modifier: Modifier = Modifier) {
+    val clipboard = LocalClipboardManager.current
     SectionCard(title = section.title, modifier = modifier) {
         section.fields.forEachIndexed { index, field ->
             KeyValueRow(
                 label = field.label,
                 value = field.value,
-                monospace = field.label == "CRC" || field.label.startsWith("GUID")
+                monospace = field.label == "CRC" || field.label.startsWith("GUID"),
+                onCopy = { clipboard.setText(AnnotatedString(field.value)) }
             )
             if (index < section.fields.lastIndex) {
                 HorizontalDivider(color = MaterialTheme.colorScheme.surfaceVariant)

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="scanner_parse_complete">parse completo</string>
     <string name="scanner_parse_partial">parse parcial (%1$d/%2$d caracteres)</string>
     <string name="scanner_raw_section">Texto crudo</string>
+    <string name="copy_value">Copiar valor</string>
     <string name="scanner_scan_again">Escanear otro</string>
 
     <!-- Cámara -->

--- a/iosApp/iosApp/Core/UI/SharedComponents.swift
+++ b/iosApp/iosApp/Core/UI/SharedComponents.swift
@@ -1,20 +1,39 @@
 import SwiftUI
 
-/// Fila etiqueta/valor para los campos decodificados.
+/// Fila etiqueta/valor para los campos decodificados, con copiado al portapapeles.
 struct KeyValueRow: View {
     let label: String
     let value: String
     var monospace: Bool = false
 
+    @State private var justCopied = false
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(label)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Text(value)
-                .font(monospace ? .body.monospaced() : .body)
+        HStack(alignment: .center, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(monospace ? .body.monospaced() : .body)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button {
+                UIPasteboard.general.string = value
+                withAnimation { justCopied = true }
+                Task {
+                    try? await Task.sleep(nanoseconds: 1_500_000_000)
+                    withAnimation { justCopied = false }
+                }
+            } label: {
+                Image(systemName: justCopied ? "checkmark" : "doc.on.doc")
+                    .font(.footnote)
+                    .foregroundStyle(justCopied ? AnyShapeStyle(.green) : AnyShapeStyle(.tertiary))
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel("Copiar valor")
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 


### PR DESCRIPTION
## Summary

Each field row in the scanner results gets a trailing copy icon ("two sheets") that copies the value to the clipboard:
- **Android**: `KeyValueRow` gains an optional `onCopy`; scanner sections wire it to `LocalClipboardManager`. Android 13+ shows the system copied-overlay as feedback.
- **iOS**: borderless `doc.on.doc` button per row with a 1.5s checkmark animation as feedback; copies via `UIPasteboard`.

Both apps build green (`assembleDebug` + `xcodebuild` simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)